### PR TITLE
Adding markdown to Depends of Description

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,11 +41,11 @@ Imports:
     tidyr,
     tidyselect,
     tippy,
-    RColorBrewer
+    RColorBrewer,
+    markdown
 Suggests:
     kableExtra,
     knitr,
-    markdown,
     ResultModelManager,
     RSQLite,
     testthat,


### PR DESCRIPTION
Cohorts in CohortDiagnostics will not display on positconnect/rconnect if this isn't a requirement of the package. 
Unfortunatley, there isn't a way to force posit connect to install a required package. It either has to be called in a shiny app.R directly or a requirement of a package. In this case, because it's in Suggests the publish tool will ignore it.