### PR TITLE
fix(prediction): show algorithm names with modelType fallback

### DIFF
--- a/R/patient-level-prediction-main.R
+++ b/R/patient-level-prediction-main.R
@@ -31,6 +31,18 @@ patientLevelPredictionHelperFile <- function(){
   return(fileLoc)
 }
 
+normalizePredictionAlgorithmName <- function(performances) {
+  if (!"algorithmName" %in% colnames(performances)) {
+    performances$algorithmName <- performances$modelType
+    return(performances)
+  }
+
+  missingAlgorithmName <- is.na(performances$algorithmName) | trimws(performances$algorithmName) == ""
+  performances$algorithmName[missingAlgorithmName] <- performances$modelType[missingAlgorithmName]
+
+  performances
+}
+
 #' The module viewer for exploring PatientLevelPrediction
 #'
 #' @details
@@ -133,13 +145,15 @@ patientLevelPredictionServer <- function(
         databaseTable = resultDatabaseSettings$databaseTable, 
         databaseTablePrefix = resultDatabaseSettings$databaseTablePrefix
       ) %>%
+        normalizePredictionAlgorithmName() %>%
         dplyr::relocate("performanceId") %>%
         dplyr::relocate("developmentDatabase", .after = "performanceId") %>%
         dplyr::relocate("developmentTargetName", .after = "developmentDatabase") %>%
         dplyr::relocate("developmentOutcomeName", .after = "developmentTargetName") %>%
         dplyr::relocate("developmentTimeAtRisk", .after = "developmentOutcomeName") %>%
         dplyr::relocate("modelDesignId", .after = "developmentTimeAtRisk") %>%
-        dplyr::relocate("validationDatabase", .after = "modelDesignId") %>%
+        dplyr::relocate("algorithmName", .after = "modelDesignId") %>%
+        dplyr::relocate("validationDatabase", .after = "algorithmName") %>%
         dplyr::relocate("validationTargetName", .after = "validationDatabase") %>%
         dplyr::relocate("validationOutcomeName", .after = "validationTargetName") %>%
         dplyr::relocate("validationTimeAtRisk", .after = "validationOutcomeName") %>%
@@ -158,12 +172,12 @@ patientLevelPredictionServer <- function(
             name = 'Performance ID',
             show = TRUE
             ),
-          madeUp = reactable::colDef(name = 'testing'),
           covariateName = reactable::colDef(
             name = 'Covariates', 
             minWidth = 200
             ),
           modelDesignId = reactable::colDef(name = 'Model ID'),
+          algorithmName = reactable::colDef(name = 'Algorithm'),
           developmentDatabaseId = reactable::colDef(show = FALSE),
           validationDatabaseId  = reactable::colDef(show = FALSE),
           developmentTargetId = reactable::colDef(show = FALSE),
@@ -559,6 +573,4 @@ patientLevelPredictionServer <- function(
     }
   )
 }
-
-
 

--- a/R/patient-level-prediction-model.R
+++ b/R/patient-level-prediction-model.R
@@ -433,8 +433,10 @@ patientLevelPredictionModelServer <- function(
           output$viewModelDesign <- shiny::reactive(0)
           
           uniqueModels <- unique(performances()[performanceRowIds(),] %>%
+                                   normalizePredictionAlgorithmName() %>%
                                    dplyr::select(
                                      'modelDesignId',
+                                     'algorithmName',
                                      'modelType',
                                      'developmentDatabase',
                                      "developmentTargetName", 
@@ -443,7 +445,8 @@ patientLevelPredictionModelServer <- function(
                                      'developmentDatabaseId'
                                    ))
           
-          uniqueModels$name <- paste0('Model ', uniqueModels$modelDesignId, ' a ', uniqueModels$modelType,
+          uniqueModels$name <- paste0('Model ', uniqueModels$modelDesignId, ': ', uniqueModels$algorithmName,
+                                      ' (', uniqueModels$modelType, ')',
                                       ' predicting ', uniqueModels$developmentOutcomeName, ' in ', 
                                       uniqueModels$developmentTargetName, ' during ', uniqueModels$developmentTimeAtRisk, 
                                       ' in ', uniqueModels$developmentDatabase )
@@ -497,15 +500,18 @@ patientLevelPredictionModelServer <- function(
           output$viewModelDesign <- shiny::reactive(1)
           
           uniqueModels <- unique(performances()[performanceRowIds(),] %>%
+                                   normalizePredictionAlgorithmName() %>%
                                    dplyr::select(
                                      'modelDesignId',
+                                     'algorithmName',
                                      'modelType',
                                      "developmentTargetName", 
                                      "developmentOutcomeName", 
                                      'developmentTimeAtRisk'
                                    ))
           
-          uniqueModels$name <- paste0('Model ', uniqueModels$modelDesignId, ' a ', uniqueModels$modelType,
+          uniqueModels$name <- paste0('Model ', uniqueModels$modelDesignId, ': ', uniqueModels$algorithmName,
+                                      ' (', uniqueModels$modelType, ')',
                                       ' predicting ', uniqueModels$developmentOutcomeName, ' in ', 
                                       uniqueModels$developmentTargetName, ' during ', uniqueModels$developmentTimeAtRisk)
           
@@ -683,4 +689,3 @@ addValidationName <- function(result){
   
   return(result)
 }
-

--- a/tests/testthat/test-patient-level-prediction-main.R
+++ b/tests/testthat/test-patient-level-prediction-main.R
@@ -1,40 +1,64 @@
 context("patient-level-prediction-main")
 
 shiny::testServer(
-  app = patientLevelPredictionServer, 
+  app = patientLevelPredictionServer,
   args = list(
     connectionHandler = connectionHandlerCharacterization,
     resultDatabaseSettings = resultDatabaseSettingsCharacterization
-  ), 
+  ),
   expr = {
-    
+
     expect_true(performanceRowId() == 0)
-    testthat::expect_is(performances, 'data.frame')
-    expect_true(nrow(performances) > 0 )
-    
-    
+    testthat::expect_is(performances, "data.frame")
+    expect_true(nrow(performances) > 0)
+    expect_true("algorithmName" %in% colnames(performances))
+    expect_false(any(is.na(performances$algorithmName)))
+    expect_false(any(trimws(performances$algorithmName) == ""))
+
     # set the performanceRowId()
     performanceRowId(1)
-    
+
     # check each view loads selects tab
-    session$setInputs(tabView = 'View Models')
+    session$setInputs(tabView = "View Models")
     session$flushReact()
-    
+
     # add check to see whether tab changed
     #testthat::expect_true(input$resultTab == 'View Models')
-  
-    session$setInputs(tabView = 'Generate Plots')
+
+    session$setInputs(tabView = "Generate Plots")
     #testthat::expect_true(input$resultTab == 'Generate Plots')
-    
-    session$setInputs(tabView = 'View Threshold Performances')
+
+    session$setInputs(tabView = "View Threshold Performances")
     #testthat::expect_true(input$resultTab == 'View Threshold Performances')
-    
-    session$setInputs(tabView = 'View Diagnostics')
+
+    session$setInputs(tabView = "View Diagnostics")
     #testthat::expect_true(input$resultTab == 'View Diagnostics')
-    
-    
+
+
   })
 
+
+test_that("normalizePredictionAlgorithmName fills missing names", {
+  input <- data.frame(
+    modelType = c("binary", "survival"),
+    stringsAsFactors = FALSE
+  )
+  result <- normalizePredictionAlgorithmName(input)
+
+  expect_true("algorithmName" %in% colnames(result))
+  expect_identical(result$algorithmName, input$modelType)
+})
+
+test_that("normalizePredictionAlgorithmName fills blank algorithm names", {
+  input <- data.frame(
+    modelType = c("binary", "survival", "binary"),
+    algorithmName = c(NA, "", "xgboost"),
+    stringsAsFactors = FALSE
+  )
+  result <- normalizePredictionAlgorithmName(input)
+
+  expect_identical(result$algorithmName, c("binary", "survival", "xgboost"))
+})
 
 
 test_that("Test prediction ui", {
@@ -42,6 +66,3 @@ test_that("Test prediction ui", {
   ui <- patientLevelPredictionViewer()
   checkmate::expect_list(ui)
 })
-
-
-

--- a/tests/testthat/test-patient-level-prediction-model.R
+++ b/tests/testthat/test-patient-level-prediction-model.R
@@ -2,13 +2,14 @@ context("patient-level-prediction-model")
 
 # extract performances
 performances <- OhdsiReportGenerator::getFullPredictionPerformances(
-  connectionHandler = connectionHandlerCharacterization, 
+  connectionHandler = connectionHandlerCharacterization,
   schema = resultDatabaseSettingsCharacterization$schema,
-  plpTablePrefix = resultDatabaseSettingsCharacterization$plpTablePrefix, 
+  plpTablePrefix = resultDatabaseSettingsCharacterization$plpTablePrefix,
   cgTablePrefix = resultDatabaseSettingsCharacterization$cgTablePrefix,
-  databaseTable = resultDatabaseSettingsCharacterization$databaseTable, 
+  databaseTable = resultDatabaseSettingsCharacterization$databaseTable,
   databaseTablePrefix = resultDatabaseSettingsCharacterization$databaseTablePrefix
 ) %>%
+  normalizePredictionAlgorithmName() %>%
   dplyr::relocate("developmentTargetName") %>%
   dplyr::relocate("developmentOutcomeName", .after = "developmentTargetName") %>%
   dplyr::relocate("developmentTimeAtRisk", .after = "developmentOutcomeName") %>%
@@ -17,42 +18,73 @@ performances <- OhdsiReportGenerator::getFullPredictionPerformances(
 
 
 shiny::testServer(
-  app = patientLevelPredictionModelServer, 
+  app = patientLevelPredictionModelServer,
   args = list(
     performances = shiny::reactive({performances}),
     performanceRowIds = shiny::reactiveVal(1),
     connectionHandler = connectionHandlerCharacterization,
     resultDatabaseSettings = resultDatabaseSettingsCharacterization
-  ), 
+  ),
   expr = {
-    
-    # check generate works for all model views 
+
+    # check generate works for all model views
     i <- 0
-    for(viewOption in c('Model Variable Importance','Univariate Variable Importance', 'Model Design', 'Hyperparameters')){
-      i <- i + 1 
+    for (viewOption in c("Model Variable Importance", "Univariate Variable Importance", "Model Design", "Hyperparameters")) {
+      i <- i + 1
       session$setInputs(
         view = viewOption,
         select = i
       )
       session$flushReact()
-    
     }
+
+    expect_false(is.null(hyperparameterSettings()))
+    expect_true("algorithmName" %in% colnames(hyperparameterSettings()))
+    expect_true(grepl("\\(.+\\)", hyperparameterSettings()$name[[1]]))
 
   })
 
 
+test_that("hyperparameter selector falls back to modelType", {
+  fallbackPerformances <- performances
+  fallbackPerformances$algorithmName <- NA_character_
+
+  shiny::testServer(
+    app = patientLevelPredictionModelServer,
+    args = list(
+      performances = shiny::reactive({fallbackPerformances}),
+      performanceRowIds = shiny::reactiveVal(1),
+      connectionHandler = connectionHandlerCharacterization,
+      resultDatabaseSettings = resultDatabaseSettingsCharacterization
+    ),
+    expr = {
+      session$setInputs(
+        view = "Hyperparameters",
+        select = 1
+      )
+      session$flushReact()
+
+      expect_false(is.null(hyperparameterSettings()))
+      expect_identical(
+        hyperparameterSettings()$algorithmName[[1]],
+        hyperparameterSettings()$modelType[[1]]
+      )
+    }
+  )
+})
+
+
 test_that("Test prediction model ui", {
   # Test ui
-  ui <- patientLevelPredictionModelViewer(id = 'models')
+  ui <- patientLevelPredictionModelViewer(id = "models")
   checkmate::expect_list(ui)
 })
 
 test_that("predictionModelColumns", {
   # Test ui
   cols <- predictionModelColumns()
-  testthat::expect_is(cols, 'list')
+  testthat::expect_is(cols, "list")
 })
 
 
 # TODO add test for addValidationName
-


### PR DESCRIPTION
## Summary
- normalize prediction performance rows to always include `algorithmName`, falling back to `modelType` when missing/blank
- use `algorithmName` in model/hyperparameter selector labels while keeping `modelType` in parentheses
- add `Algorithm` column to the main performance selection table and remove placeholder `madeUp` column

## Why
Shiny model and hyperparameter views were showing generic binary/survival labels instead of algorithm labels, and could break when legacy result schemas lacked `algorithmName`.

## Validation
- ran `devtools::test(filter = "patient-level-prediction-(main|model)")`
- added tests for algorithm-name normalization and fallback behavior in selectors
